### PR TITLE
feat: refresh quotas in bulk and auto sync image usage

### DIFF
--- a/backend/api/config_handlers.go
+++ b/backend/api/config_handlers.go
@@ -38,6 +38,8 @@ type configPayload struct {
 		DefaultQuota        int  `json:"defaultQuota"`
 		PreferRemoteRefresh bool `json:"preferRemoteRefresh"`
 		RefreshWorkers      int  `json:"refreshWorkers"`
+		AutoRefreshEnabled  bool `json:"autoRefreshEnabled"`
+		AutoRefreshInterval int  `json:"autoRefreshInterval"`
 	} `json:"accounts"`
 	Storage struct {
 		AuthDir      string `json:"authDir"`
@@ -119,9 +121,11 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 			"studio_allow_disabled_image_accounts": payload.ChatGPT.StudioAllowDisabledImageAccounts,
 		},
 		"accounts": {
-			"default_quota":         payload.Accounts.DefaultQuota,
-			"prefer_remote_refresh": payload.Accounts.PreferRemoteRefresh,
-			"refresh_workers":       payload.Accounts.RefreshWorkers,
+			"default_quota":                 payload.Accounts.DefaultQuota,
+			"prefer_remote_refresh":         payload.Accounts.PreferRemoteRefresh,
+			"refresh_workers":               payload.Accounts.RefreshWorkers,
+			"auto_refresh_enabled":          payload.Accounts.AutoRefreshEnabled,
+			"auto_refresh_interval_minutes": payload.Accounts.AutoRefreshInterval,
 		},
 		"storage": {
 			"auth_dir":       payload.Storage.AuthDir,
@@ -201,6 +205,8 @@ func (s *Server) buildConfigPayloadFromConfig(cfg *config.Config) configPayload 
 	payload.Accounts.DefaultQuota = cfg.Accounts.DefaultQuota
 	payload.Accounts.PreferRemoteRefresh = cfg.Accounts.PreferRemoteRefresh
 	payload.Accounts.RefreshWorkers = cfg.Accounts.RefreshWorkers
+	payload.Accounts.AutoRefreshEnabled = cfg.Accounts.AutoRefreshEnabled
+	payload.Accounts.AutoRefreshInterval = cfg.Accounts.AutoRefreshInterval
 
 	payload.Storage.AuthDir = cfg.Storage.AuthDir
 	payload.Storage.StateFile = cfg.Storage.StateFile

--- a/backend/internal/accounts/store.go
+++ b/backend/internal/accounts/store.go
@@ -201,6 +201,78 @@ func NewStore(cfg *config.Config) (*Store, error) {
 	return store, nil
 }
 
+func (s *Store) defaultQuotaValue() int {
+	if s != nil && s.cfg != nil {
+		return max(1, s.cfg.Accounts.DefaultQuota)
+	}
+	return max(1, s.defaultQuota)
+}
+
+func (s *Store) refreshWorkersValue() int {
+	if s != nil && s.cfg != nil {
+		return max(1, s.cfg.Accounts.RefreshWorkers)
+	}
+	return max(1, s.refreshWorkers)
+}
+
+func (s *Store) autoRefreshConfig() (bool, time.Duration) {
+	if s == nil || s.cfg == nil {
+		return false, 30 * time.Minute
+	}
+	intervalMinutes := max(1, s.cfg.Accounts.AutoRefreshInterval)
+	return s.cfg.Accounts.AutoRefreshEnabled, time.Duration(intervalMinutes) * time.Minute
+}
+
+func (s *Store) RunAutoRefreshLoop(ctx context.Context) {
+	if s == nil {
+		return
+	}
+
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	var lastRun time.Time
+	for {
+		enabled, interval := s.autoRefreshConfig()
+		if !enabled {
+			lastRun = time.Time{}
+		} else if lastRun.IsZero() || time.Since(lastRun) >= interval {
+			requestTimeoutSeconds := 120
+			if s.cfg != nil {
+				requestTimeoutSeconds = max(30, s.cfg.ChatGPT.RequestTimeout)
+			}
+
+			runCtx, cancel := context.WithTimeout(ctx, time.Duration(requestTimeoutSeconds)*time.Second)
+			refreshed, refreshErrors, err := s.RefreshAccounts(runCtx, nil)
+			cancel()
+			lastRun = time.Now()
+
+			switch {
+			case err != nil:
+				slog.Warn("auto refresh accounts failed", "error", err)
+			case len(refreshErrors) > 0:
+				slog.Warn(
+					"auto refresh accounts completed with errors",
+					"refreshed",
+					refreshed,
+					"errors",
+					len(refreshErrors),
+					"first_error",
+					refreshErrors[0].Error,
+				)
+			default:
+				slog.Info("auto refresh accounts completed", "refreshed", refreshed)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
 func (s *Store) ListAccounts() ([]PublicAccount, error) {
 	localAuths, err := s.loadAuths()
 	if err != nil {
@@ -270,7 +342,7 @@ func (s *Store) AddAccounts(tokens []string) (int, int, error) {
 			state.Email = firstNonEmpty(stringValue(authData["email"]), guessEmail(authData))
 			state.UserID = firstNonEmpty(stringValue(authData["user_id"]), guessUserID(authData))
 			if !state.QuotaKnown {
-				state.Quota = s.defaultQuota
+				state.Quota = s.defaultQuotaValue()
 				state.Status = "正常"
 			}
 			return state
@@ -418,7 +490,7 @@ func (s *Store) ImportAuthFiles(files []ImportedAuthFile) (int, []string, []Impo
 			state.Email = firstNonEmpty(stringValue(targetData["email"]), guessEmail(targetData), state.Email)
 			state.UserID = firstNonEmpty(stringValue(targetData["user_id"]), guessUserID(targetData), state.UserID)
 			if !state.QuotaKnown {
-				state.Quota = s.defaultQuota
+				state.Quota = s.defaultQuotaValue()
 				if boolValue(targetData["disabled"]) {
 					state.Status = "禁用"
 				} else {
@@ -505,7 +577,7 @@ func (s *Store) RefreshAccounts(ctx context.Context, accessTokens []string) (int
 
 	jobs := make(chan string)
 	results := make(chan refreshResult, len(targets))
-	workers := minInt(max(1, s.refreshWorkers), max(1, len(targets)))
+	workers := minInt(s.refreshWorkersValue(), max(1, len(targets)))
 	for i := 0; i < workers; i++ {
 		go func() {
 			for token := range jobs {
@@ -1122,7 +1194,7 @@ func (s *Store) buildPublicAccount(auth LocalAuth, syncState SyncState, remoteDi
 	accountType := firstNonEmpty(state.Type, normalizePlanType(guessPlanFromPayload(auth.Data)), "Free")
 	quota := state.Quota
 	if !state.QuotaKnown {
-		quota = s.defaultQuota
+		quota = s.defaultQuotaValue()
 	}
 	limitsProgress := cloneSlice(state.LimitsProgress)
 	status := strings.TrimSpace(state.Status)

--- a/backend/internal/accounts/store_test.go
+++ b/backend/internal/accounts/store_test.go
@@ -57,6 +57,73 @@ func TestNeedsImageQuotaRefreshByResetTime(t *testing.T) {
 	}
 }
 
+func TestRecordImageResultDecrementsLocalQuotaAndImageLimit(t *testing.T) {
+	rootDir := t.TempDir()
+	authDir := filepath.Join(rootDir, "auths")
+	syncDir := filepath.Join(rootDir, "sync")
+	if err := os.MkdirAll(authDir, 0o755); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.MkdirAll(syncDir, 0o755); err != nil {
+		t.Fatalf("mkdir sync dir: %v", err)
+	}
+
+	const token = "token-record-image-result"
+	store := &Store{
+		authDir:      authDir,
+		syncStateDir: syncDir,
+		stateFile:    filepath.Join(rootDir, "state.json"),
+		defaultQuota: 5,
+		providerType: "codex",
+		states: map[string]RuntimeState{
+			"record.json": {
+				Type:       "Plus",
+				Status:     "正常",
+				Quota:      1,
+				QuotaKnown: true,
+				LimitsProgress: []map[string]any{
+					{
+						"feature_name": "image_gen",
+						"remaining":    1,
+					},
+				},
+			},
+		},
+	}
+
+	if err := writeJSONFile(filepath.Join(authDir, "record.json"), map[string]any{
+		"type":         "codex",
+		"access_token": token,
+		"email":        "record@example.com",
+	}); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store.RecordImageResult(token, true)
+
+	state := store.getState("record.json")
+	if state.Success != 1 {
+		t.Fatalf("expected success count 1, got %d", state.Success)
+	}
+	if state.Quota != 0 {
+		t.Fatalf("expected quota 0, got %d", state.Quota)
+	}
+	if state.Status != "限流" {
+		t.Fatalf("expected status 限流, got %q", state.Status)
+	}
+
+	imageRemaining := -1
+	for _, item := range state.LimitsProgress {
+		if strings.TrimSpace(strings.ToLower(stringValue(item["feature_name"]))) != "image_gen" {
+			continue
+		}
+		imageRemaining = intValue(item["remaining"])
+	}
+	if imageRemaining != 0 {
+		t.Fatalf("expected image_gen remaining 0, got %d", imageRemaining)
+	}
+}
+
 func TestImportAuthFilesSkipsDuplicateToken(t *testing.T) {
 	rootDir := t.TempDir()
 	authDir := filepath.Join(rootDir, "auths")

--- a/backend/internal/config/config.defaults.toml
+++ b/backend/internal/config/config.defaults.toml
@@ -48,6 +48,8 @@ studio_allow_disabled_image_accounts = false
 default_quota = 5
 prefer_remote_refresh = true
 refresh_workers = 6
+auto_refresh_enabled = true
+auto_refresh_interval_minutes = 30
 
 [storage]
 auth_dir = "data/auths"

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -63,6 +63,8 @@ type AccountsConfig struct {
 	DefaultQuota        int  `toml:"default_quota"`
 	PreferRemoteRefresh bool `toml:"prefer_remote_refresh"`
 	RefreshWorkers      int  `toml:"refresh_workers"`
+	AutoRefreshEnabled  bool `toml:"auto_refresh_enabled"`
+	AutoRefreshInterval int  `toml:"auto_refresh_interval_minutes"`
 }
 
 type StorageConfig struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -61,6 +61,9 @@ func main() {
 
 	syncTimeout := time.Duration(max(10, cfg.Sync.RequestTimeout)) * time.Second
 	syncClient := cliproxy.New(cfg.Sync.Enabled, cfg.Sync.BaseURL, cfg.Sync.ManagementKey, cfg.Sync.ProviderType, syncTimeout, cfg.SyncProxyURL())
+	backgroundCtx, backgroundCancel := context.WithCancel(context.Background())
+	defer backgroundCancel()
+	go store.RunAutoRefreshLoop(backgroundCtx)
 
 	host := envString("SERVER_HOST", cfg.Server.Host)
 	port := envInt("SERVER_PORT", cfg.Server.Port)
@@ -108,6 +111,7 @@ func main() {
 		logger.Info("shutdown signal received")
 	}
 
+	backgroundCancel()
 	shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	_ = server.Shutdown(shutCtx)

--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -264,17 +264,19 @@ export default function AccountsPage() {
   const [isSyncLoading, setIsSyncLoading] = useState(true);
   const [syncRunningDirection, setSyncRunningDirection] = useState<"pull" | "push" | null>(null);
 
+  const replaceAccounts = (items: Account[]) => {
+    setAccounts(normalizeAccounts(items));
+    setAccountQuotaMap({});
+    setSelectedIds((prev) => prev.filter((id) => items.some((item) => item.id === id)));
+  };
+
   const loadAccounts = async (silent = false) => {
     if (!silent) {
       setIsLoading(true);
     }
     try {
       const data = await fetchAccounts();
-      setAccounts(normalizeAccounts(data.items));
-      setAccountQuotaMap((prev) =>
-        Object.fromEntries(Object.entries(prev).filter(([id]) => data.items.some((item) => item.id === id))),
-      );
-      setSelectedIds((prev) => prev.filter((id) => data.items.some((item) => item.id === id)));
+      replaceAccounts(data.items);
     } catch (error) {
       const message = error instanceof Error ? error.message : "加载账户失败";
       toast.error(message);
@@ -407,8 +409,7 @@ export default function AccountsPage() {
     setIsImporting(true);
     try {
       const data = await importAccountFiles(normalizedFiles);
-      setAccounts(normalizeAccounts(data.items));
-      setSelectedIds((prev) => prev.filter((id) => data.items.some((item) => item.id === id)));
+      replaceAccounts(data.items);
       setPage(1);
       await loadSync({ silent: true, force: true });
 
@@ -437,8 +438,7 @@ export default function AccountsPage() {
     setIsDeleting(true);
     try {
       const data = await deleteAccounts(tokens);
-      setAccounts(normalizeAccounts(data.items));
-      setSelectedIds((prev) => prev.filter((id) => data.items.some((item) => item.id === id)));
+      replaceAccounts(data.items);
       await loadSync({ silent: true, force: true });
       toast.success(`删除 ${data.removed ?? 0} 个账户`);
     } catch (error) {
@@ -449,8 +449,8 @@ export default function AccountsPage() {
     }
   };
 
-  const handleRefreshSelectedAccounts = async (accessTokens: string[]) => {
-    if (accessTokens.length === 0) {
+  const handleRefreshAccounts = async (accessTokens: string[], mode: "selected" | "all") => {
+    if (mode === "selected" && accessTokens.length === 0) {
       toast.error("没有需要刷新的账户");
       return;
     }
@@ -458,15 +458,14 @@ export default function AccountsPage() {
     setIsRefreshing(true);
     try {
       const data = await refreshAccounts(accessTokens);
-      setAccounts(normalizeAccounts(data.items));
-      setSelectedIds((prev) => prev.filter((id) => data.items.some((item) => item.id === id)));
+      replaceAccounts(data.items);
       if (data.errors.length > 0) {
         const firstError = data.errors[0]?.error;
         toast.error(
           `刷新成功 ${data.refreshed} 个，失败 ${data.errors.length} 个${firstError ? `，首个错误：${firstError}` : ""}`,
         );
       } else {
-        toast.success(`刷新成功 ${data.refreshed} 个账户`);
+        toast.success(mode === "all" ? `已一键刷新全部账户，共 ${data.refreshed} 个` : `刷新成功 ${data.refreshed} 个账户`);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : "刷新账户失败";
@@ -549,9 +548,8 @@ export default function AccountsPage() {
         status: editStatus,
         quota: Number(editQuota || 0),
       });
-      setAccounts(normalizeAccounts(data.items));
-    setSelectedIds((prev) => prev.filter((id) => data.items.some((item) => item.id === id)));
-    setEditingAccount(null);
+      replaceAccounts(data.items);
+      setEditingAccount(null);
       toast.success("账号信息已更新");
     } catch (error) {
       const message = error instanceof Error ? error.message : "更新账号失败";
@@ -894,7 +892,16 @@ export default function AccountsPage() {
                 <Button
                   variant="ghost"
                   className="h-8 rounded-lg px-3 text-stone-500 hover:bg-stone-100"
-                  onClick={() => void handleRefreshSelectedAccounts(selectedTokens)}
+                  onClick={() => void handleRefreshAccounts([], "all")}
+                  disabled={accounts.length === 0 || isRefreshing}
+                >
+                  {isRefreshing ? <LoaderCircle className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}
+                  一键刷新全部额度
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="h-8 rounded-lg px-3 text-stone-500 hover:bg-stone-100"
+                  onClick={() => void handleRefreshAccounts(selectedTokens, "selected")}
                   disabled={selectedTokens.length === 0 || isRefreshing}
                 >
                   {isRefreshing ? <LoaderCircle className="size-4 animate-spin" /> : <RefreshCw className="size-4" />}

--- a/web/src/app/image/hooks/use-image-submit.ts
+++ b/web/src/app/image/hooks/use-image-submit.ts
@@ -67,6 +67,7 @@ type UseImageSubmitOptions = {
   setSubmitElapsedSeconds: (value: number) => void;
   setSubmitStartedAt: (value: number | null) => void;
   persistConversation: (conversation: ImageConversation) => Promise<void>;
+  syncQuotaAfterResult: (images: StoredImage[]) => void;
   updateConversation: (
     conversationId: string,
     updater: (current: ImageConversation | null) => ImageConversation,
@@ -118,6 +119,7 @@ export function useImageSubmit({
   setSubmitElapsedSeconds,
   setSubmitStartedAt,
   persistConversation,
+  syncQuotaAfterResult,
   updateConversation,
   resetComposer,
 }: UseImageSubmitOptions) {
@@ -227,6 +229,7 @@ export function useImageSubmit({
         });
       }
       const resultItems = mergeResultImages(turnId, data.data || [], 1);
+      syncQuotaAfterResult(resultItems);
       const failedCount = countFailures(resultItems);
 
       await updateConversation(conversationId, (current) => ({
@@ -288,6 +291,7 @@ export function useImageSubmit({
     setSubmitStartedAt,
     updateConversation,
     upscaleScale,
+    syncQuotaAfterResult,
   ]);
 
   const handleRetryTurn = useCallback(async (conversationId: string, turn: ImageConversationTurn) => {
@@ -393,6 +397,7 @@ export function useImageSubmit({
         resultItems = mergeResultImages(turnId, data.data || [], 1);
       }
 
+      syncQuotaAfterResult(resultItems);
       const failedCount = countFailures(resultItems);
       await updateConversation(conversationId, (current) => ({
         ...(current ?? buildConversationBase(conversationId, draftTurn)),
@@ -439,7 +444,17 @@ export function useImageSubmit({
       setActiveRequest(null);
       setSubmitStartedAt(null);
     }
-  }, [focusConversation, isSubmitting, setActiveRequest, setIsSubmitting, setSubmitElapsedSeconds, setSubmitStartedAt, updateConversation, upscaleScale]);
+  }, [
+    focusConversation,
+    isSubmitting,
+    setActiveRequest,
+    setIsSubmitting,
+    setSubmitElapsedSeconds,
+    setSubmitStartedAt,
+    syncQuotaAfterResult,
+    updateConversation,
+    upscaleScale,
+  ]);
 
   const handleSubmit = useCallback(async () => {
     const prompt = imagePrompt.trim();
@@ -547,6 +562,7 @@ export function useImageSubmit({
         resultItems = mergeResultImages(turnId, data.data || [], 1);
       }
 
+      syncQuotaAfterResult(resultItems);
       const failedCount = countFailures(resultItems);
       await updateConversation(conversationId, (current) => ({
         ...(current ?? buildConversationBase(conversationId, draftTurn)),
@@ -623,6 +639,7 @@ export function useImageSubmit({
     setSubmitElapsedSeconds,
     setSubmitStartedAt,
     sourceImages,
+    syncQuotaAfterResult,
     updateConversation,
     upscaleScale,
   ]);

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -5,7 +5,7 @@ import "react-medium-image-zoom/dist/styles.css";
 import { ChevronsDown } from "lucide-react";
 
 import { ImageEditModal } from "@/components/image-edit-modal";
-import { fetchAccounts, fetchConfig, type Account, type ImageQuality } from "@/lib/api";
+import { fetchAccountQuota, fetchAccounts, fetchConfig, type Account, type ImageQuality } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import {
   normalizeConversation,
@@ -13,6 +13,7 @@ import {
   updateImageConversation,
   type ImageConversation,
   type ImageMode,
+  type StoredImage,
 } from "@/store/image-conversations";
 import { isImageTaskActive, listActiveImageTasks, subscribeImageTasks } from "@/store/image-active-tasks";
 import { ConversationTurns } from "./components/conversation-turns";
@@ -178,6 +179,42 @@ function getImageRemaining(account: Account) {
     return Math.max(0, limit.remaining);
   }
   return Math.max(0, account.quota);
+}
+
+function mergeImageGenLimit(
+  limitsProgress: Account["limits_progress"],
+  remaining: number | null | undefined,
+  resetAfter: string | null | undefined,
+) {
+  const next = Array.isArray(limitsProgress) ? [...limitsProgress] : [];
+  const currentIndex = next.findIndex((item) => item.feature_name === "image_gen");
+  const nextItem = {
+    feature_name: "image_gen",
+    remaining: typeof remaining === "number" ? remaining : undefined,
+    reset_after: resetAfter || undefined,
+  };
+
+  if (currentIndex >= 0) {
+    next[currentIndex] = {
+      ...next[currentIndex],
+      ...nextItem,
+    };
+    return next;
+  }
+
+  next.push(nextItem);
+  return next;
+}
+
+function applyQuotaResultToAccount(account: Account, quota: Awaited<ReturnType<typeof fetchAccountQuota>>): Account {
+  return {
+    ...account,
+    status: quota.status,
+    type: quota.type,
+    quota: quota.quota,
+    restoreAt: quota.image_gen_reset_after || account.restoreAt,
+    limits_progress: mergeImageGenLimit(account.limits_progress, quota.image_gen_remaining, quota.image_gen_reset_after),
+  };
 }
 
 function isImageAccountUsable(account: Account, allowDisabled: boolean) {
@@ -347,9 +384,9 @@ export default function ImagePage() {
   const [upscaleScale, setUpscaleScale] = useState("2x");
   const [historyCollapsed, setHistoryCollapsed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [availableQuota, setAvailableQuota] = useState("加载中");
   const [availableAccounts, setAvailableAccounts] = useState<Account[]>([]);
   const [allowDisabledStudioAccounts, setAllowDisabledStudioAccounts] = useState(false);
+  const [isQuotaLoading, setIsQuotaLoading] = useState(true);
   const [activeRequest, setActiveRequest] = useState<ActiveRequestState | null>(null);
   const [submitStartedAt, setSubmitStartedAt] = useState<number | null>(null);
   const [submitElapsedSeconds, setSubmitElapsedSeconds] = useState(0);
@@ -442,6 +479,10 @@ export default function ImagePage() {
     () => hasAvailablePaidImageAccount(availableAccounts, allowDisabledStudioAccounts),
     [allowDisabledStudioAccounts, availableAccounts],
   );
+  const availableQuota = useMemo(
+    () => (isQuotaLoading ? "加载中" : formatAvailableQuota(availableAccounts, allowDisabledStudioAccounts)),
+    [allowDisabledStudioAccounts, availableAccounts, isQuotaLoading],
+  );
   const currentResolutionPresets = useMemo(() => imageResolutionPresets[imageAspectRatio], [imageAspectRatio]);
   const imageResolutionTierOptions = useMemo(
     () =>
@@ -495,6 +536,25 @@ export default function ImagePage() {
     [activeRequest, submitElapsedSeconds],
   );
   const waitingDots = useMemo(() => buildWaitingDots(submitElapsedSeconds), [submitElapsedSeconds]);
+  const syncQuotaAfterResult = useCallback((images: StoredImage[]) => {
+    const sourceAccountID =
+      images.find((item) => item.status === "success" && item.source_account_id)?.source_account_id ??
+      images.find((item) => item.source_account_id)?.source_account_id;
+    if (!sourceAccountID) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const quota = await fetchAccountQuota(sourceAccountID, { refresh: false });
+        setAvailableAccounts((prev) =>
+          prev.map((account) => (account.id === sourceAccountID ? applyQuotaResultToAccount(account, quota) : account)),
+        );
+      } catch {
+        // Keep the current quota snapshot when a best-effort sync fails.
+      }
+    })();
+  }, []);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -534,17 +594,18 @@ export default function ImagePage() {
 
   useEffect(() => {
     const loadQuota = async () => {
+      setIsQuotaLoading(true);
       try {
         const [accountsData, configData] = await Promise.all([fetchAccounts(), fetchConfig()]);
         const allowDisabled =
           configData.chatgpt.imageMode === "studio" && configData.chatgpt.studioAllowDisabledImageAccounts;
         setAllowDisabledStudioAccounts(allowDisabled);
         setAvailableAccounts(accountsData.items);
-        setAvailableQuota(formatAvailableQuota(accountsData.items, allowDisabled));
       } catch {
         setAvailableAccounts([]);
         setAllowDisabledStudioAccounts(false);
-        setAvailableQuota((prev) => (prev === "加载中" ? "—" : prev));
+      } finally {
+        setIsQuotaLoading(false);
       }
     };
 
@@ -732,6 +793,7 @@ export default function ImagePage() {
     setSubmitElapsedSeconds,
     setSubmitStartedAt,
     persistConversation,
+    syncQuotaAfterResult,
     updateConversation,
     resetComposer,
   });

--- a/web/src/app/settings/components/runtime-section.tsx
+++ b/web/src/app/settings/components/runtime-section.tsx
@@ -428,6 +428,66 @@ export function RuntimeSection({ config, setSection }: RuntimeSectionProps) {
         />
       </Field>
       <ToggleField
+        label="自动定时刷新额度"
+        hint="后端会按设定周期自动刷新全部账号的图片额度与状态。"
+        tooltip={
+          <TooltipDetails
+            items={[
+              {
+                title: "开启后",
+                body: <>服务会在后台按周期刷新全部账号，不需要手动一页页勾选。</>,
+              },
+              {
+                title: "适合场景",
+                body: <>账号很多、经常跨页管理时，建议开启，图片工作台和账号页的额度会更稳定。</>,
+              },
+              {
+                title: "注意",
+                body: <>这是后台定时任务，不需要页面保持打开；刷新频率越高，对上游请求也越频繁。</>,
+              },
+            ]}
+          />
+        }
+        checked={config.accounts.autoRefreshEnabled}
+        onCheckedChange={(checked) =>
+          setSection("accounts", {
+            ...config.accounts,
+            autoRefreshEnabled: checked,
+          })
+        }
+      />
+      <Field
+        label="自动刷新间隔（分钟）"
+        hint="后台定时刷新额度的执行周期。"
+        tooltip={
+          <TooltipDetails
+            items={[
+              {
+                title: "建议值",
+                body: <>常用 `15`、`30`、`60` 分钟；账号越多，越建议保守一些。</>,
+              },
+              {
+                title: "设置过小",
+                body: <>会更频繁请求上游，虽然额度更实时，但也更容易增加波动和额外开销。</>,
+              },
+            ]}
+          />
+        }
+      >
+        <Input
+          type="number"
+          min="1"
+          value={String(config.accounts.autoRefreshInterval)}
+          onChange={(event) =>
+            setSection("accounts", {
+              ...config.accounts,
+              autoRefreshInterval: Number(event.target.value || 0),
+            })
+          }
+          className="h-11 rounded-2xl border-stone-200 bg-white shadow-none"
+        />
+      </Field>
+      <ToggleField
         label="优先远端刷新额度"
         hint="开启后，后端会优先尝试刷新真实额度状态，而不是只依赖本地扣减。"
         tooltip={

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -66,6 +66,8 @@ function defaultConfigPayload(): ConfigPayload {
       defaultQuota: 5,
       preferRemoteRefresh: true,
       refreshWorkers: 6,
+      autoRefreshEnabled: true,
+      autoRefreshInterval: 30,
     },
     storage: {
       authDir: "",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -171,6 +171,8 @@ export type ConfigPayload = {
     defaultQuota: number;
     preferRemoteRefresh: boolean;
     refreshWorkers: number;
+    autoRefreshEnabled: boolean;
+    autoRefreshInterval: number;
   };
   storage: {
     authDir: string;


### PR DESCRIPTION
This PR includes:
- add bulk refresh-all for account quota management
- add configurable scheduled auto-refresh for account quotas
- auto-sync image workbench remaining quota after image generation/edit/upscale
- backend config/runtime support and tests for local quota decrement behavior