### PR TITLE
fix: 为 CPA 编辑请求设置图片 MIME 类型

### DIFF
--- a/backend/api/cpa_image_client.go
+++ b/backend/api/cpa_image_client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"strings"
 	"time"
 
@@ -163,7 +164,7 @@ func (c *cpaImageClient) EditImageByUpload(ctx context.Context, prompt, model st
 	}
 
 	for index, image := range images {
-		part, err := writer.CreateFormFile("image", fmt.Sprintf("image-%d.png", index+1))
+		part, err := createCPAImageFormPart(writer, "image", fmt.Sprintf("image-%d.png", index+1), image)
 		if err != nil {
 			return nil, fmt.Errorf("create image form field: %w", err)
 		}
@@ -172,7 +173,7 @@ func (c *cpaImageClient) EditImageByUpload(ctx context.Context, prompt, model st
 		}
 	}
 	if len(mask) > 0 {
-		part, err := writer.CreateFormFile("mask", "mask.png")
+		part, err := createCPAImageFormPart(writer, "mask", "mask.png", mask)
 		if err != nil {
 			return nil, fmt.Errorf("create mask form field: %w", err)
 		}
@@ -206,6 +207,39 @@ func (c *cpaImageClient) EditImageByUpload(ctx context.Context, prompt, model st
 		return nil, fmt.Errorf("images_api failed: %v; codex_responses fallback failed: %w", parseErr, fallbackErr)
 	}
 	return results, parseErr
+}
+
+func createCPAImageFormPart(writer *multipart.Writer, fieldName, fileName string, data []byte) (io.Writer, error) {
+	mediaType, err := detectCPAUploadMIME(data)
+	if err != nil {
+		return nil, err
+	}
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name=%q; filename=%q`, fieldName, fileName))
+	header.Set("Content-Type", mediaType)
+	return writer.CreatePart(header)
+}
+
+func detectCPAUploadMIME(data []byte) (string, error) {
+	if len(data) >= 8 {
+		if data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 {
+			return "image/png", nil
+		}
+		if data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF {
+			return "image/jpeg", nil
+		}
+		if len(data) >= 12 && data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 && data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50 {
+			return "image/webp", nil
+		}
+	}
+	if len(data) >= 6 && (bytes.Equal(data[:6], []byte("GIF87a")) || bytes.Equal(data[:6], []byte("GIF89a"))) {
+		return "image/gif", nil
+	}
+	mediaType := strings.TrimSpace(http.DetectContentType(data))
+	if strings.HasPrefix(mediaType, "image/") {
+		return mediaType, nil
+	}
+	return "", fmt.Errorf("unsupported image mime type %q", mediaType)
 }
 
 func (c *cpaImageClient) InpaintImageByMask(

--- a/backend/api/cpa_image_client_test.go
+++ b/backend/api/cpa_image_client_test.go
@@ -137,6 +137,55 @@ func TestCPAImageClientEditUsesCodexResponsesMaskField(t *testing.T) {
 	}
 }
 
+func TestCPAImageClientEditUsesImagesAPIMultipartImageMIMETypes(t *testing.T) {
+	var seenImageContentType string
+	var seenMaskContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/images/edits" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/v1/images/edits")
+		}
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("MultipartReader() returned error: %v", err)
+		}
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("NextPart() returned error: %v", err)
+			}
+			switch part.FormName() {
+			case "image":
+				seenImageContentType = part.Header.Get("Content-Type")
+			case "mask":
+				seenMaskContentType = part.Header.Get("Content-Type")
+			}
+			_, _ = io.Copy(io.Discard, part)
+			_ = part.Close()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[{"b64_json":"aW1hZ2U="}]}`)
+	}))
+	defer server.Close()
+
+	client := newCPAImageClient(server.URL, "test-key", 30*time.Second, "images_api")
+	jpegImage := []byte{0xFF, 0xD8, 0xFF, 0x00}
+	pngMask := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00, 0x00}
+	_, err := client.EditImageByUpload(context.Background(), "edit cat", cpaFixedImageModel, [][]byte{jpegImage}, pngMask, "1536x1024", "high")
+	if err != nil {
+		t.Fatalf("EditImageByUpload() returned error: %v", err)
+	}
+	if seenImageContentType != "image/jpeg" {
+		t.Fatalf("image Content-Type = %q, want %q", seenImageContentType, "image/jpeg")
+	}
+	if seenMaskContentType != "image/png" {
+		t.Fatalf("mask Content-Type = %q, want %q", seenMaskContentType, "image/png")
+	}
+}
+
 func TestCPAImageClientAutoFallsBackToCodexResponses(t *testing.T) {
 	var imagesAPICalls int
 	var responsesCalls int


### PR DESCRIPTION
## Summary

修复 CPA 图片编辑请求未正确设置上传图片 MIME 类型，导致 `/v1/images/edits` 返回 400。

 - 为 CPA `/v1/images/edits` 的 multipart 上传显式设置图片 `Content-Type`
 - 按文件头识别 PNG、JPEG、WebP、GIF 的 MIME 类型
 - 补充测试，校验 image 和 mask 的 multipart MIME

## Test

 - `go test ./api -run TestCPAImageClient -count=1`